### PR TITLE
feat(server): encrypt steam credentials at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ JWT_EXPIRES_IN=1
 # Generate with `pnpm g:secret`
 JWT_SECRET=REPLACE_ME_WITH_SECRET
 
+# Encrypts Steam refresh tokens and web session cookies
+# Generate with `pnpm g:secret`
+CREDENTIALS_SECRET=REPLACE_ME_WITH_SECRET
+
 # Mongo (used when running the server outside docker; docker-compose overrides this
 # internally to point at the `steam-idler-mongo` service on the compose network).
 DATABASE_URL=mongodb://127.0.0.1:27018/steam-idler
@@ -23,4 +27,3 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_PASSWORD=REPLACE_ME_WITH_PASSWORD
 REDIS_TTL=300000
-

--- a/libs/server/infra/services/src/index.ts
+++ b/libs/server/infra/services/src/index.ts
@@ -1,3 +1,4 @@
 export { ExceptionService } from './lib/exception.service';
 export { EnvironmentService } from './lib/environment.service';
+export { EncryptionService } from './lib/encryption.service';
 export { CommonServicesModule } from './lib/common-services.module';

--- a/libs/server/infra/services/src/lib/common-services.module.ts
+++ b/libs/server/infra/services/src/lib/common-services.module.ts
@@ -1,10 +1,11 @@
 import { Global, Module } from '@nestjs/common';
 
+import { EncryptionService } from './encryption.service';
 import { ExceptionService } from './exception.service';
 
 @Global()
 @Module({
-  providers: [ExceptionService],
-  exports: [ExceptionService],
+  providers: [ExceptionService, EncryptionService],
+  exports: [ExceptionService, EncryptionService],
 })
 export class CommonServicesModule {}

--- a/libs/server/infra/services/src/lib/encryption.service.ts
+++ b/libs/server/infra/services/src/lib/encryption.service.ts
@@ -1,0 +1,89 @@
+import {
+  createCipheriv,
+  createDecipheriv,
+  createHash,
+  randomBytes,
+} from 'node:crypto';
+
+import { Injectable } from '@nestjs/common';
+
+import { EnvironmentService } from './environment.service';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;
+const ENCRYPTION_VERSION = 'v1';
+const PAYLOAD_PARTS = 4;
+
+@Injectable()
+export class EncryptionService {
+  private readonly key: Buffer;
+
+  constructor(private readonly environmentService: EnvironmentService) {
+    const secret = this.environmentService.get('CREDENTIALS_SECRET');
+
+    if (!secret) {
+      throw new Error(
+        'CREDENTIALS_SECRET is not set. Generate one with `pnpm g:secret` and add it to your .env.',
+      );
+    }
+
+    this.key = createHash('sha256').update(secret).digest();
+  }
+
+  encrypt(value: string): string {
+    if (!value) {
+      return value;
+    }
+
+    const iv = randomBytes(IV_LENGTH);
+    const cipher = createCipheriv(ALGORITHM, this.key, iv);
+    const encrypted = Buffer.concat([
+      cipher.update(value, 'utf8'),
+      cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+
+    return [
+      ENCRYPTION_VERSION,
+      iv.toString('hex'),
+      authTag.toString('hex'),
+      encrypted.toString('hex'),
+    ].join(':');
+  }
+
+  decrypt(value: string): string {
+    if (!value || !value.startsWith(`${ENCRYPTION_VERSION}:`)) {
+      return value;
+    }
+
+    const parts = value.split(':');
+
+    if (parts.length !== PAYLOAD_PARTS) {
+      return value;
+    }
+
+    const [, ivHex, authTagHex, encryptedHex] = parts;
+    const decipher = createDecipheriv(
+      ALGORITHM,
+      this.key,
+      Buffer.from(ivHex, 'hex'),
+    );
+
+    decipher.setAuthTag(Buffer.from(authTagHex, 'hex'));
+
+    const decrypted = Buffer.concat([
+      decipher.update(Buffer.from(encryptedHex, 'hex')),
+      decipher.final(),
+    ]);
+
+    return decrypted.toString('utf8');
+  }
+
+  encryptList(values: string[]): string[] {
+    return values.map((value) => this.encrypt(value));
+  }
+
+  decryptList(values: string[]): string[] {
+    return values.map((value) => this.decrypt(value));
+  }
+}

--- a/libs/server/infra/types/src/lib/env-variables.ts
+++ b/libs/server/infra/types/src/lib/env-variables.ts
@@ -6,6 +6,7 @@ export interface EnvVariables {
   SERVER_LOG_TYPE: LogLevel;
   JWT_SECRET: string;
   JWT_EXPIRES_IN: number;
+  CREDENTIALS_SECRET: string;
   REDIS_ENABLED: string;
   REDIS_HOST: string;
   REDIS_PORT: number;

--- a/libs/server/steam-account/feature/src/lib/services/steam-user.service.ts
+++ b/libs/server/steam-account/feature/src/lib/services/steam-user.service.ts
@@ -2,7 +2,10 @@ import { Injectable, Logger } from '@nestjs/common';
 
 import SteamUser from 'steam-user';
 
-import { ExceptionService } from '@steam-idler/server/infra/services';
+import {
+  EncryptionService,
+  ExceptionService,
+} from '@steam-idler/server/infra/services';
 import { ExceptionStatusKeys, MongoId } from '@steam-idler/server/infra/types';
 
 import { AuthRepository } from '@steam-idler/server/auth/domain';
@@ -27,6 +30,7 @@ export class SteamUserService {
     private readonly steamAccountRepository: SteamAccountRepository,
     private readonly authRepository: AuthRepository,
     private readonly exceptionService: ExceptionService,
+    private readonly encryptionService: EncryptionService,
   ) {
     this.init();
   }
@@ -61,14 +65,13 @@ export class SteamUserService {
     this.usersMap.set(steamSignInDto.login, steamUser);
 
     steamUser.on('refreshToken', async (refreshToken: string) => {
-      // ! TODO: THIS PART NEEDS TO BE ENCRYPTED BEFORE GOING LIVE
-      user.credentials.refreshToken = refreshToken;
+      user.credentials.refreshToken =
+        this.encryptionService.encrypt(refreshToken);
       await user.save();
     });
 
     steamUser.on('webSession', async (_, cookies: string[]) => {
-      // ! TODO: THIS PART NEEDS TO BE ENCRYPTED BEFORE GOING LIVE
-      user.credentials.cookies = cookies;
+      user.credentials.cookies = this.encryptionService.encryptList(cookies);
       await user.save();
     });
 
@@ -504,19 +507,22 @@ export class SteamUserService {
     });
 
     steamUser.on('refreshToken', async (refreshToken) => {
-      user.credentials.refreshToken = refreshToken;
+      user.credentials.refreshToken =
+        this.encryptionService.encrypt(refreshToken);
       await user.save();
     });
 
     steamUser.on('webSession', async (_, cookies) => {
-      user.credentials.cookies = cookies;
+      user.credentials.cookies = this.encryptionService.encryptList(cookies);
       await user.save();
     });
 
     this.registerAutoReply(steamUser, user.accountName);
 
     steamUser.logOn({
-      refreshToken: user.credentials.refreshToken,
+      refreshToken: this.encryptionService.decrypt(
+        user.credentials.refreshToken,
+      ),
     });
   }
 


### PR DESCRIPTION
### Description

Add `AES-256-GCM` EncryptionService and use it to encrypt Steam refresh
tokens and web session cookies before persisting them, decrypting on
re-login. Introduces the `CREDENTIALS_SECRET` env var. 

Legacy plaintext values pass through and re-encrypt on next refresh.

### Links

- [x] Fixes: #64
- [ ] Related to: #
