### PR TITLE
feat: set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -13,7 +13,7 @@
       "!{projectRoot}/src/test-setup.[jt]s",
       "!{projectRoot}/test-setup.[jt]s"
     ],
-    "sharedGlobals": []
+    "sharedGlobals": ["{workspaceRoot}/.github/workflows/*.yml"]
   },
   "plugins": [
     {
@@ -28,15 +28,24 @@
       },
       "exclude": ["tools/generators/**/*"]
     },
-    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
+    {
+      "plugin": "@nx/eslint/plugin",
+      "options": {
+        "targetName": "lint"
+      }
+    },
     {
       "plugin": "@nx/jest/plugin",
-      "options": { "targetName": "test" },
+      "options": {
+        "targetName": "test"
+      },
       "exclude": ["apps/server-e2e/**/*", "tools/generators/**/*"]
     },
     {
       "plugin": "@nx/playwright/plugin",
-      "options": { "targetName": "e2e" },
+      "options": {
+        "targetName": "e2e"
+      },
       "exclude": ["tools/generators/**/*"]
     }
   ],
@@ -59,8 +68,13 @@
       "style": "scss",
       "unitTestRunner": "jest"
     },
-    "@nx/angular:library": { "linter": "eslint", "unitTestRunner": "jest" },
-    "@nx/angular:component": { "style": "scss" }
+    "@nx/angular:library": {
+      "linter": "eslint",
+      "unitTestRunner": "jest"
+    },
+    "@nx/angular:component": {
+      "style": "scss"
+    }
   },
   "release": {
     "projects": ["infra"],
@@ -72,13 +86,48 @@
     },
     "conventionalCommits": {
       "types": {
-        "refactor": { "semverBump": "none", "changelog": { "hidden": false } },
-        "chore": { "semverBump": "none", "changelog": { "hidden": false } },
-        "docs": { "semverBump": "none", "changelog": { "hidden": false } },
-        "style": { "semverBump": "none", "changelog": { "hidden": false } },
-        "test": { "semverBump": "none", "changelog": { "hidden": false } },
-        "ci": { "semverBump": "none", "changelog": { "hidden": false } },
-        "build": { "semverBump": "none", "changelog": { "hidden": false } }
+        "refactor": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false
+          }
+        },
+        "chore": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false
+          }
+        },
+        "docs": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false
+          }
+        },
+        "style": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false
+          }
+        },
+        "test": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false
+          }
+        },
+        "ci": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false
+          }
+        },
+        "build": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false
+          }
+        }
       }
     },
     "changelog": {

--- a/nx.json
+++ b/nx.json
@@ -28,24 +28,15 @@
       },
       "exclude": ["tools/generators/**/*"]
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/jest/plugin",
-      "options": {
-        "targetName": "test"
-      },
+      "options": { "targetName": "test" },
       "exclude": ["apps/server-e2e/**/*", "tools/generators/**/*"]
     },
     {
       "plugin": "@nx/playwright/plugin",
-      "options": {
-        "targetName": "e2e"
-      },
+      "options": { "targetName": "e2e" },
       "exclude": ["tools/generators/**/*"]
     }
   ],
@@ -68,13 +59,8 @@
       "style": "scss",
       "unitTestRunner": "jest"
     },
-    "@nx/angular:library": {
-      "linter": "eslint",
-      "unitTestRunner": "jest"
-    },
-    "@nx/angular:component": {
-      "style": "scss"
-    }
+    "@nx/angular:library": { "linter": "eslint", "unitTestRunner": "jest" },
+    "@nx/angular:component": { "style": "scss" }
   },
   "release": {
     "projects": ["infra"],
@@ -86,48 +72,13 @@
     },
     "conventionalCommits": {
       "types": {
-        "refactor": {
-          "semverBump": "none",
-          "changelog": {
-            "hidden": false
-          }
-        },
-        "chore": {
-          "semverBump": "none",
-          "changelog": {
-            "hidden": false
-          }
-        },
-        "docs": {
-          "semverBump": "none",
-          "changelog": {
-            "hidden": false
-          }
-        },
-        "style": {
-          "semverBump": "none",
-          "changelog": {
-            "hidden": false
-          }
-        },
-        "test": {
-          "semverBump": "none",
-          "changelog": {
-            "hidden": false
-          }
-        },
-        "ci": {
-          "semverBump": "none",
-          "changelog": {
-            "hidden": false
-          }
-        },
-        "build": {
-          "semverBump": "none",
-          "changelog": {
-            "hidden": false
-          }
-        }
+        "refactor": { "semverBump": "none", "changelog": { "hidden": false } },
+        "chore": { "semverBump": "none", "changelog": { "hidden": false } },
+        "docs": { "semverBump": "none", "changelog": { "hidden": false } },
+        "style": { "semverBump": "none", "changelog": { "hidden": false } },
+        "test": { "semverBump": "none", "changelog": { "hidden": false } },
+        "ci": { "semverBump": "none", "changelog": { "hidden": false } },
+        "build": { "semverBump": "none", "changelog": { "hidden": false } }
       }
     },
     "changelog": {
@@ -143,5 +94,6 @@
       "commitMessage": "chore(release): {version} [skip ci]",
       "tag": true
     }
-  }
+  },
+  "nxCloudId": "6a3b8aee407541c5d71ef270"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/6a3b8aed618f969a3e6e86d2/workspaces/6a3b8aee407541c5d71ef270

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.